### PR TITLE
feat: Exclude merge commits from changelog

### DIFF
--- a/src/main/groovy/com/github/rising3/gradle/semver/git/GitProvider.groovy
+++ b/src/main/groovy/com/github/rising3/gradle/semver/git/GitProvider.groovy
@@ -23,6 +23,7 @@ import org.eclipse.jgit.lib.Ref
 import org.eclipse.jgit.lib.ReflogEntry
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.revwalk.RevCommit
+import org.eclipse.jgit.revwalk.filter.RevFilter
 
 /**
  * Git Provider.
@@ -128,6 +129,8 @@ interface GitProvider {
 	 */
 	Iterable<RevCommit> log()
 
+	Iterable<RevCommit> log(RevFilter revFilter)
+
 	/**
 	 * Get git log list.
 	 *
@@ -136,6 +139,8 @@ interface GitProvider {
 	 * @return RevCommits
 	 */
 	Iterable<RevCommit> log(AnyObjectId since, AnyObjectId until)
+
+	Iterable<RevCommit> log(AnyObjectId since, AnyObjectId until, RevFilter revFilter)
 
 	/**
 	 * Get git tag list.

--- a/src/main/groovy/com/github/rising3/gradle/semver/git/GitProviderImpl.groovy
+++ b/src/main/groovy/com/github/rising3/gradle/semver/git/GitProviderImpl.groovy
@@ -15,6 +15,9 @@
  */
 package com.github.rising3.gradle.semver.git
 
+import org.eclipse.jgit.api.MergeCommand
+import org.eclipse.jgit.revwalk.filter.RevFilter
+
 import java.nio.file.Paths
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.Status
@@ -146,11 +149,21 @@ class GitProviderImpl implements GitProvider {
 
 	@Override
 	Iterable<RevCommit> log() {
-		git?.log()?.call() ?: []
+		log(null)
+	}
+
+	@Override
+	Iterable<RevCommit> log(RevFilter revFilter) {
+		git?.log()?.setRevFilter (revFilter)?.call() ?: []
 	}
 
 	@Override
 	Iterable<RevCommit> log(AnyObjectId since, AnyObjectId until) {
+		return log(since, until, null)
+	}
+
+	@Override
+	Iterable<RevCommit> log(AnyObjectId since, AnyObjectId until, RevFilter revFilter) {
 		git?.log()?.addRange(since, until)?.call() ?: []
 	}
 
@@ -162,6 +175,18 @@ class GitProviderImpl implements GitProvider {
 	@Override
 	String getBranch() {
 		git?.getRepository()?.getBranch()
+	}
+
+	void checkoutBranch(String name) {
+		git?.checkout()?.setName(name)?.call()
+	}
+
+	void createAndSwitchToBranch(String name) {
+		git?.checkout()?.setName(name)?.setCreateBranch(true)?.call()
+	}
+
+	void mergeBranch(String branch) {
+		git?.merge()?.include(git?.repository?.findRef(branch))?.setFastForward(MergeCommand.FastForwardMode.NO_FF)?.call()
 	}
 
 	@Override

--- a/src/main/groovy/com/github/rising3/gradle/semver/tasks/internal/DefaultLogOperation.groovy
+++ b/src/main/groovy/com/github/rising3/gradle/semver/tasks/internal/DefaultLogOperation.groovy
@@ -24,6 +24,7 @@ import com.github.rising3.gradle.semver.tasks.LogOperation
 import org.eclipse.jgit.api.errors.NoHeadException
 import org.eclipse.jgit.lib.Constants
 import org.eclipse.jgit.revwalk.RevCommit
+import org.eclipse.jgit.revwalk.filter.RevFilter
 
 /**
  * Default log operation.
@@ -73,12 +74,12 @@ class DefaultLogOperation implements LogOperation {
         try {
             final currentVersion = git.findRef("${Constants.R_TAGS}${ext.versionTagPrefix}${version}")
             if (Objects.isNull(currentVersion)) {
-                git.log()
+                git.log(RevFilter.NO_MERGES)
             } else {
                 final from = currentVersion.isPeeled()
                         ? currentVersion.getPeeledObjectId()
                         : git.peel(currentVersion).getPeeledObjectId()
-                git.log(from, git.head())
+                git.log(from, git.head(), RevFilter.NO_MERGES)
             }
         } catch(NoHeadException e) {
             []

--- a/src/test/groovy/com/github/rising3/gradle/semver/tasks/internal/DefaultLogOperationTest.groovy
+++ b/src/test/groovy/com/github/rising3/gradle/semver/tasks/internal/DefaultLogOperationTest.groovy
@@ -73,7 +73,7 @@ class DefaultLogOperationTest extends Specification {
         gitRepo.commit('README.md', 'test: commit')
         gitRepo.commit('README.md', 'build!: commit')
         gitRepo.commit('README.md', 'revert: commit')
-        gitRepo.commit('README.md', 'other: commit')
+        gitRepo.commitAndMerge('README.md', 'other: commit')
     }
 
     def "Should generate changelog"() {
@@ -110,6 +110,7 @@ class DefaultLogOperationTest extends Specification {
         actual.count('revert:') == 1
         actual.count(ext.changeLogTitle['__undefined__']) == 1
         actual.count('other:') == 1
+        actual.count('Merge branch') == 0
     }
 
     def "Should generate changelog with custom order"() {

--- a/src/test/groovy/helper/GitRepositoryHelper.groovy
+++ b/src/test/groovy/helper/GitRepositoryHelper.groovy
@@ -99,6 +99,16 @@ class GitRepositoryHelper {
         local.commit(message)
     }
 
+    void commitAndMerge(String filename, String message) {
+        writeFile(localDir, filename, UUID.randomUUID().toString())
+        def local = new GitProviderImpl(getLocalDirectory())
+        def oldBranch = local.getBranch()
+        local.createAndSwitchToBranch('some-branch')
+        local.commit(message)
+        local.checkoutBranch(oldBranch)
+        local.mergeBranch('some-branch')
+    }
+
     private def newWorkRepository(File dir) {
         if (!Paths.get(dir.toString(), ".git").toFile().exists()) {
             Git.init().setDirectory(dir)?.setBare(false)?.setInitialBranch('master')?.call()


### PR DESCRIPTION
Merge commits don't have any changes, there is no sense in processing them.

In most projects, commits aren't added directly to the main branch, but are merged instead. But tests never set up any merges. This commit adds a merge to make sure they are correctly handled.